### PR TITLE
Anchor link error corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ This repository is the official PyTorch implementation of SwinIR: Image Restorat
 
 #### Contents
 
-1. [Training](#Training)
-1. [Testing](#Testing)
-1. [Results](#Results)
-1. [Citation](#Citation)
-1. [License and Acknowledgement](#License-and-Acknowledgement)
+1. [Training](#training)
+1. [Testing](#testing-without-preparing-datasets)
+1. [Results](#results)
+1. [Citation](#citation)
+1. [License and Acknowledgement](#license-and-acknowledgement)
 
 
 ### Training


### PR DESCRIPTION
Thank you for publishing this wonderful implementation.

Some of the anchors in the README had broken links, so I have committed, albeit a minor fix.
![image](https://user-images.githubusercontent.com/33194443/165515224-26b092ba-5bd5-42e9-84a2-3f84352605ec.png)
