### PR TITLE
Update readme to use an easier version of the colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Computer Vision Lab, ETH Zurich
 [![GitHub Stars](https://img.shields.io/github/stars/JingyunLiang/SwinIR?style=social)](https://github.com/JingyunLiang/SwinIR)
 [![download](https://img.shields.io/github/downloads/JingyunLiang/SwinIR/total.svg)](https://github.com/JingyunLiang/SwinIR/releases)
 ![visitors](https://visitor-badge.glitch.me/badge?page_id=jingyunliang/SwinIR)
-[ <a href="https://colab.research.google.com/gist/JingyunLiang/a5e3e54bc9ef8d7bf594f6fee8208533/swinir-demo-on-real-world-image-sr.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="google colab logo"></a>](https://colab.research.google.com/gist/JingyunLiang/a5e3e54bc9ef8d7bf594f6fee8208533/swinir-demo-on-real-world-image-sr.ipynb)
+[ <a href="https://colab.research.google.com/gist/renxida/dab94c3bb50445a439d8651d86bd135c/swinir-demo-on-real-world-image-sr.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="google colab logo"></a>](https://colab.research.google.com/gist/renxida/dab94c3bb50445a439d8651d86bd135c/swinir-demo-on-real-world-image-sr.ipynb)
 <a href="https://replicate.ai/jingyunliang/swinir"><img src="https://img.shields.io/static/v1?label=Replicate&message=Demo and Docker Image&color=blue"></a>
 [![PlayTorch Demo](https://github.com/facebookresearch/playtorch/blob/main/website/static/assets/playtorch_badge.svg)](https://playtorch.dev/snack/@playtorch/swinir/)
 [Gradio Web Demo](https://huggingface.co/spaces/akhaliq/SwinIR)


### PR DESCRIPTION
Compared to [the original](https://colab.research.google.com/gist/JingyunLiang/a5e3e54bc9ef8d7bf594f6fee8208533/swinir-demo-on-real-world-image-sr.ipynb), this version:
- prompts the user to upload images before installing any dependencies.
- uses UV instead of pip to install dependencies, which is faster.
- works out of the box. clicking "run all cells" would prompt the user to upload and automatically run the generation until download is ready. The whole process takes around 10 minutes, including upload and download time.


@JingyunLiang in light of [the recent backdoor attack through the oss supply chain](https://blog.gitguardian.com/the-backdoor-that-almost-compromised-ssh-security/), it's probably better to make the same edits on your colab notebook instead of merging this pr, as using my link gives my git account full control over the colab notebook people open.